### PR TITLE
Ask sqlite to free up unused space

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,8 @@ function PersistentQueue(filename, batchSize) {
 	// Set instance to empty on empty event
 	this.on('empty', () => {
 		this.empty = true ;
+		// Ask sqlite to free up unused space
+		this.db.exec("VACUUM;")
 	}) ;
 
 	// If a job is added, trigger_next event


### PR DESCRIPTION
Thanks a lot for this module! We are using it together with `node-red-contrib-msg-queue`.

Sqlite is lazy to free up unused space. Because of the nature of a queue which aims to be empty, we can safely launch VACUUM which frees up unused space when the queue is empty again, preventing disk space from getting filled up.

This PR goes together with a PR we would like to make to `node-red-contrib-msg-queue`.

Please let us know what you think!