### PR TITLE
fix: ensure context binding allows for passing this.lastID

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,17 +367,18 @@ PersistentQueue.prototype.abort = function() {
  */
 PersistentQueue.prototype.add = function(job) {
 
+	const self = this ;
 
 	return new Promise((resolve, reject) => {
-		this.db.run('INSERT INTO ' + table + ' (job) VALUES (?)', JSON.stringify(job), err => {
+		this.db.run('INSERT INTO ' + table + ' (job) VALUES (?)', JSON.stringify(job), function(err) {
 			if(err)
 				reject(err) ;
 
 			// Increment our job length
-			this.length++ ;
+			self.length++ ;
 
 			this.emit('add', { id: this.lastID, job: job }) ;
-			resolve(this.id) ;
+			resolve(this.lastID) ;
 		}) ;
 	}) ;
 } ;


### PR DESCRIPTION
## Problem

The fat-arrow changed the execution context such that 'this' no longer pointed to the node-sqlite statement object, which meant that the promise returned from `add` didn't resolve to a number.

## Solution

I've replaced the fat arrow-function with a `function`, and explicitly bound the outer context to `self`.