### PR TITLE
fix: ensure proper context for emit

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,7 +377,7 @@ PersistentQueue.prototype.add = function(job) {
 			// Increment our job length
 			self.length++ ;
 
-			this.emit('add', { id: this.lastID, job: job }) ;
+			self.emit('add', { id: this.lastID, job: job }) ;
 			resolve(this.lastID) ;
 		}) ;
 	}) ;


### PR DESCRIPTION
## Problem

The [patch that I submitted yesterday](https://github.com/damoclark/node-persistent-queue/pull/20) fixed the issue with `lastID`, but introduced a regression in that the 'this' in 'this.emit' was pointing to the database context.

## Context

I need to `self.emit` instead of `this.emit`.